### PR TITLE
Always pre-drop temporary relations

### DIFF
--- a/dbt/include/athena/macros/materializations/models/table/create_table_as.sql
+++ b/dbt/include/athena/macros/materializations/models/table/create_table_as.sql
@@ -42,6 +42,10 @@
     {% do adapter.delete_from_s3(location) %}
   {%- endif -%}
 
+  {%- if temporary -%}
+    {%- do drop_relation(relation) -%}
+  {%- endif -%}
+
   {%- if language == 'python' -%}
     {%- set spark_ctas = '' -%}
     {%- if table_type == 'iceberg' -%}


### PR DESCRIPTION
Athena does not implement real (transaction-bound) temporary tables, so if an execution is interrupted, it may leave the table in an unknown state, causing errors on the next run.

To work around this, always drop temporary tables before attempting to create them.

# Description

<!--- Add a little description on what you plan to tackle with this PR -->
<!--- Add resolve #issue-number in case you resolve an open issue -->

## Models used to test - Optional
<!--- Add here the models that you use to test the changes -->

## Checklist

- [ ] You followed [contributing section](https://github.com/dbt-athena/dbt-athena#contributing)
- [ ] You kept your Pull Request small and focused on a single feature or bug fix.
- [ ] You added unit testing when necessary
- [ ] You added functional testing when necessary
